### PR TITLE
Fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN apt update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY entrypoint.sh ./
-ENTRYPOINT ["./entrypoint.sh"]
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:latest
 
 RUN apt update \
-  && apt install -y openscad \
-  && apt clean \
+  && apt-get install -y openscad \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh ./


### PR DESCRIPTION
# Fix warning

* `apt` is not preferrable in Dockerfile. You should continue to use `apt-get` in Dockerfile.

# Fix error

* Placing the entrypoint by relative path causes OCI runtime error e.g. https://github.com/namachan10777/scad-ml/runs/3912737011